### PR TITLE
Update getvalue() to 0.4 compatibility

### DIFF
--- a/src/lininterp.jl
+++ b/src/lininterp.jl
@@ -118,7 +118,7 @@ end
 
 function getValue(l::Lininterp,x::Vector{Float64})
 	# make sure all get evaluated
-	l.ifunc = [1:l.nfunc]
+	l.ifunc = collect(1:l.nfunc)
 	if l.n == 1
 		eval1D(l,x)
 	elseif l.n == 2
@@ -134,7 +134,7 @@ end
 function getValue(l::Lininterp,y::Float64)
 	# make sure all get evaluated
 	x = [y]
-	l.ifunc = [1:l.nfunc]
+	l.ifunc = collect(1:l.nfunc)
 	if l.n == 1
 		eval1D(l,x)
 	elseif l.n == 2


### PR DESCRIPTION
`[]` concatenation is deprecated, replaced with `collect()` - this should be non-breaking, as `collect` will work in 0.3 as well.